### PR TITLE
Need purl property for Dependency Track

### DIFF
--- a/src/Covenant.CycloneDx/CycloneDxConverter.cs
+++ b/src/Covenant.CycloneDx/CycloneDxConverter.cs
@@ -97,6 +97,7 @@ internal static class CycloneDxConverter
         var result = new CycloneComponent
         {
             BomRef = component.Purl,
+            Purl = component.Purl,
             Name = component.Name,
             Version = component.Version,
             Type = ConvertKind(component.Kind),


### PR DESCRIPTION
The Package URL needs to be set as a property in order for the OWASP Dependency Track project to be able to analyze for vulnerabilities. This could potentially be something bigger to investigate since the Package URL has a strict format.