### PR TITLE
Fix Scriban loop limit exceeded when rendering large HTML reports

### DIFF
--- a/src/Covenant/Reporting/ReportGenerator.cs
+++ b/src/Covenant/Reporting/ReportGenerator.cs
@@ -1,4 +1,5 @@
 using Scriban;
+using Scriban.Runtime;
 
 namespace Covenant.Reporting;
 
@@ -10,8 +11,11 @@ public sealed class ReportGenerator
         var templateHtml = EmbeddedResourceReader.Read("Covenant/Reporting/Templates/Template.html");
         var template = Template.Parse(templateHtml);
 
-        // Render template
-        var context = new ReportContext(bom);
-        return template.Render(new { bom = context });
+        // Render template. Loop limit disabled: large SBOMs routinely exceed Scriban's default
+        // 1000-iteration cap, and Template.html is a trusted, fixed resource, not user input.
+        var templateContext = new TemplateContext { LoopLimit = 0 };
+        templateContext.PushGlobal(new ScriptObject { ["bom"] = new ReportContext(bom) });
+
+        return template.Render(templateContext);
     }
 }


### PR DESCRIPTION
Fixes #30

Report generation crashes on SBOMs with more than 1000 components/dependencies, since Template.Render(object) uses Scriban's default TemplateContext, which caps loops at 1000 iterations to guard against runaway templates.

Set LoopLimit = 0 (disabled) because Template.html is a fixed, trusted embedded resource we control, not user-supplied input, so that guard isn't needed here.