### PR TITLE
Update vulnerable dependencies flagged by NuGet audit

### DIFF
--- a/src/Covenant/Covenant.csproj
+++ b/src/Covenant/Covenant.csproj
@@ -48,6 +48,7 @@
     <!-- Override vulnerable versions -->
     <PackageReference Include="Microsoft.Build" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -11,10 +11,10 @@
     <PackageVersion Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="NuGet.Packaging" Version="7.0.0" />
+    <PackageVersion Include="NuGet.Packaging" Version="7.9.0" />
     <PackageVersion Include="Rosetta" Version="0.7.0" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.14.1" />
-    <PackageVersion Include="Scriban" Version="6.5.1" />
+    <PackageVersion Include="Scriban" Version="7.2.6" />
     <PackageVersion Include="Semver" Version="3.0.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="Spdx" Version="0.11.0" />
@@ -22,6 +22,7 @@
     <PackageVersion Include="Spectre.Console.Analyzer" Version="1.0.0" />
     <PackageVersion Include="Spectre.IO" Version="0.21.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.4" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
Resolves NuGet audit errors failing CI (see #31), unrelated to that PR's actual fix.

Bumps NuGet.Packaging, Scriban, and System.Security.Cryptography.Xml to their
latest patched versions to clear the known vulnerabilities.